### PR TITLE
Count playground regions with walls

### DIFF
--- a/playground.py
+++ b/playground.py
@@ -1,0 +1,60 @@
+class UnionFind:
+    def __init__(self, n):
+        self.parent = list(range(n))
+        self.rank = [0] * n
+        self.components = n
+    
+    def find(self, x):
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+    
+    def union(self, x, y):
+        px, py = self.find(x), self.find(y)
+        if px == py:
+            return
+        if self.rank[px] < self.rank[py]:
+            px, py = py, px
+        self.parent[py] = px
+        if self.rank[px] == self.rank[py]:
+            self.rank[px] += 1
+        self.components -= 1
+
+def playground(N, M, Q, A):
+    uf = UnionFind(N * M)
+    
+    walls = set()
+    for wall in A:
+        x1, y1, x2, y2 = wall
+        x1 -= 1
+        y1 -= 1
+        x2 -= 1
+        y2 -= 1
+        if x1 > x2 or (x1 == x2 and y1 > y2):
+            x1, y1, x2, y2 = x2, y2, x1, y1
+        walls.add((x1, y1, x2, y2))
+    
+    for i in range(N):
+        for j in range(M):
+            cell = i * M + j
+            
+            if i < N - 1:
+                neighbor = (i + 1) * M + j
+                if (i, j, i + 1, j) not in walls:
+                    uf.union(cell, neighbor)
+            
+            if j < M - 1:
+                neighbor = i * M + (j + 1)
+                if (i, j, i, j + 1) not in walls:
+                    uf.union(cell, neighbor)
+    
+    return uf.components
+
+T = int(input())
+for _ in range(T):
+    N, M, Q = map(int, input().split())
+    A = []
+    for _ in range(Q):
+        wall = list(map(int, input().split()))
+        A.append(wall)
+    print(playground(N, M, Q, A))

--- a/solution.py
+++ b/solution.py
@@ -1,0 +1,51 @@
+class UnionFind:
+    def __init__(self, n):
+        self.parent = list(range(n))
+        self.rank = [0] * n
+        self.components = n
+    
+    def find(self, x):
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+    
+    def union(self, x, y):
+        px, py = self.find(x), self.find(y)
+        if px == py:
+            return
+        if self.rank[px] < self.rank[py]:
+            px, py = py, px
+        self.parent[py] = px
+        if self.rank[px] == self.rank[py]:
+            self.rank[px] += 1
+        self.components -= 1
+
+def playground(N, M, Q, A):
+    uf = UnionFind(N * M)
+    
+    walls = set()
+    for wall in A:
+        x1, y1, x2, y2 = wall
+        x1 -= 1
+        y1 -= 1
+        x2 -= 1
+        y2 -= 1
+        if x1 > x2 or (x1 == x2 and y1 > y2):
+            x1, y1, x2, y2 = x2, y2, x1, y1
+        walls.add((x1, y1, x2, y2))
+    
+    for i in range(N):
+        for j in range(M):
+            cell = i * M + j
+            
+            if i < N - 1:
+                neighbor = (i + 1) * M + j
+                if (i, j, i + 1, j) not in walls:
+                    uf.union(cell, neighbor)
+            
+            if j < M - 1:
+                neighbor = i * M + (j + 1)
+                if (i, j, i, j + 1) not in walls:
+                    uf.union(cell, neighbor)
+    
+    return uf.components


### PR DESCRIPTION
Implements a Union-Find based solution to count regions in a grid divided by walls. This approach efficiently determines the number of connected components in the grid after walls are placed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8bee372-17fe-49f8-9109-c9617dd2079b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8bee372-17fe-49f8-9109-c9617dd2079b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

